### PR TITLE
feat: White Hat Hacker investigate role (#79)

### DIFF
--- a/apps/server/src/domain/game/role-actions.test.ts
+++ b/apps/server/src/domain/game/role-actions.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import { NightActionType, RoleId, Team } from '@tattletale/shared';
+import { validateRoleAction } from './role-actions.js';
+
+describe('validateRoleAction — WHITE_HAT_HACKER', () => {
+  it('allows a WHITE_HAT_HACKER to submit INVESTIGATE', () => {
+    const result = validateRoleAction({
+      roleId: RoleId.WHITE_HAT_HACKER,
+      team: Team.FRIENDS,
+      actionType: NightActionType.INVESTIGATE,
+    });
+    expect(result).toEqual({ allowed: true });
+  });
+
+  it('rejects a WHITE_HAT_HACKER submitting an action they do not own', () => {
+    const result = validateRoleAction({
+      roleId: RoleId.WHITE_HAT_HACKER,
+      team: Team.FRIENDS,
+      actionType: NightActionType.HACKER_KILL,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'ROLE_CANNOT_SUBMIT_ACTION' });
+  });
+
+  it('rejects INVESTIGATE from a role that is not mapped to it', () => {
+    const result = validateRoleAction({
+      roleId: RoleId.HACKER,
+      team: Team.HACKERS,
+      actionType: NightActionType.INVESTIGATE,
+    });
+    expect(result).toEqual({ allowed: false, reason: 'ROLE_CANNOT_SUBMIT_ACTION' });
+  });
+});

--- a/apps/server/src/domain/game/role-actions.ts
+++ b/apps/server/src/domain/game/role-actions.ts
@@ -37,7 +37,7 @@ export const NIGHT_ACTION_TIER: Record<NightActionType, 1 | 2 | 3 | 4 | 5> = {
  */
 export const ROLE_ACTION_MAP: Record<string, readonly NightActionType[]> = {
   SECURITY_SPECIALIST: [NightActionType.PROTECT],
-  WHITE_HAT: [NightActionType.INVESTIGATE],
+  WHITE_HAT_HACKER: [NightActionType.INVESTIGATE],
   EAVESDROPPER: [NightActionType.MONITOR],
   SIGNAL_JAMMER: [NightActionType.JAM],
   TROLLER: [NightActionType.MISDIRECT],

--- a/apps/web/src/apps/TattleStation/InvestigatePanel.jsx
+++ b/apps/web/src/apps/TattleStation/InvestigatePanel.jsx
@@ -1,37 +1,61 @@
-import useGameStore from '../../stores/gameStore';
+import { useMemo, useState } from 'react';
+import { IntentType, NightActionType } from '@tattletale/shared';
+import useGameStore, { selectInvestigateCandidates } from '../../stores/gameStore';
 import { useSocket } from '../../lib/SocketContext';
 
 export default function InvestigatePanel() {
   const socket = useSocket();
   const players = useGameStore((s) => s.players);
   const selfId = useGameStore((s) => s.selfId);
+  const cycle = useGameStore((s) => s.cycle);
   const pendingSelection = useGameStore((s) => s.pendingInvestigateSelection);
   const selectInvestigateTarget = useGameStore((s) => s.selectInvestigateTarget);
-  const pendingIntentTypes = useGameStore((s) => s.pendingIntentTypes);
+  const investigateSubmittedCycle = useGameStore((s) => s.investigateSubmittedCycle);
+  const markInvestigateSubmitted = useGameStore((s) => s.markInvestigateSubmitted);
 
-  const candidates = Object.values(players).filter(
-    (p) => p.alive && p.playerId !== selfId,
+  // useMemo avoids returning a new array reference on every render, which
+  // Zustand v5 would otherwise flag as an unstable snapshot.
+  const candidates = useMemo(
+    () => selectInvestigateCandidates({ players, selfId }),
+    [players, selfId],
   );
 
-  const hasSubmitted = pendingIntentTypes.includes('SUBMIT_NIGHT_ACTION');
+  const [error, setError] = useState(null);
+
+  const hasSubmitted = investigateSubmittedCycle === cycle;
 
   const handleConfirm = async () => {
     if (!pendingSelection || hasSubmitted) return;
+    // Defense-in-depth: the candidate list already filters these out, but guard
+    // against a stale pendingSelection pointing at self or a player who just died.
+    const target = candidates.find((p) => p.playerId === pendingSelection);
+    if (!target || pendingSelection === selfId) {
+      setError('That target is no longer valid.');
+      return;
+    }
     try {
+      setError(null);
       await socket.send('submitIntent', {
         intent: {
-          type: 'SUBMIT_NIGHT_ACTION',
+          type: IntentType.SUBMIT_NIGHT_ACTION,
           payload: {
-            actionType: 'INVESTIGATE',
+            actionType: NightActionType.INVESTIGATE,
             targetPlayerId: pendingSelection,
             metadata: {},
           },
           clientTimestamp: new Date().toISOString(),
         },
       });
+      markInvestigateSubmitted(cycle);
     } catch (err) {
-      console.error('Failed to submit investigate action:', err);
+      setError(err?.message ?? 'Failed to submit investigate action.');
     }
+  };
+
+  const handleSelect = (playerId) => {
+    if (hasSubmitted) return;
+    setError(null);
+    selectInvestigateTarget(playerId);
   };
 
   return (
@@ -50,13 +74,28 @@ export default function InvestigatePanel() {
       <div style={{ fontWeight: 'bold', marginBottom: 8, color: '#60a5fa' }}>
         Pick a player to investigate tonight.
       </div>
-      <div style={{ flex: 1, overflowY: 'auto' }}>
+      <div style={{ flex: 1, overflowY: 'auto' }} role="listbox" aria-label="Investigate targets">
+        {candidates.length === 0 && (
+          <div style={{ color: '#94a3b8', fontStyle: 'italic' }}>
+            No valid targets available.
+          </div>
+        )}
         {candidates.map((p) => {
           const isSelected = pendingSelection === p.playerId;
           return (
             <div
               key={p.playerId}
-              onClick={() => !hasSubmitted && selectInvestigateTarget(p.playerId)}
+              role="option"
+              tabIndex={hasSubmitted ? -1 : 0}
+              aria-selected={isSelected}
+              aria-disabled={hasSubmitted}
+              onClick={() => handleSelect(p.playerId)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' || e.key === ' ') {
+                  e.preventDefault();
+                  handleSelect(p.playerId);
+                }
+              }}
               style={{
                 padding: '6px 8px',
                 cursor: hasSubmitted ? 'default' : 'pointer',
@@ -65,6 +104,7 @@ export default function InvestigatePanel() {
                 justifyContent: 'space-between',
                 borderRadius: 2,
                 marginBottom: 2,
+                outline: 'none',
               }}
             >
               <span>{p.displayName}</span>
@@ -72,6 +112,14 @@ export default function InvestigatePanel() {
           );
         })}
       </div>
+      {error && (
+        <div
+          role="alert"
+          style={{ marginTop: 8, color: '#fca5a5', fontSize: 11 }}
+        >
+          {error}
+        </div>
+      )}
       <button
         type="button"
         onClick={handleConfirm}

--- a/apps/web/src/apps/TattleStation/InvestigatePanel.jsx
+++ b/apps/web/src/apps/TattleStation/InvestigatePanel.jsx
@@ -1,0 +1,85 @@
+import useGameStore from '../../stores/gameStore';
+import { useSocket } from '../../lib/SocketContext';
+
+export default function InvestigatePanel() {
+  const socket = useSocket();
+  const players = useGameStore((s) => s.players);
+  const selfId = useGameStore((s) => s.selfId);
+  const pendingSelection = useGameStore((s) => s.pendingInvestigateSelection);
+  const selectInvestigateTarget = useGameStore((s) => s.selectInvestigateTarget);
+  const pendingIntentTypes = useGameStore((s) => s.pendingIntentTypes);
+
+  const candidates = Object.values(players).filter(
+    (p) => p.alive && p.playerId !== selfId,
+  );
+
+  const hasSubmitted = pendingIntentTypes.includes('SUBMIT_NIGHT_ACTION');
+
+  const handleConfirm = async () => {
+    if (!pendingSelection || hasSubmitted) return;
+    try {
+      await socket.send('submitIntent', {
+        intent: {
+          type: 'SUBMIT_NIGHT_ACTION',
+          payload: {
+            actionType: 'INVESTIGATE',
+            targetPlayerId: pendingSelection,
+            metadata: {},
+          },
+          clientTimestamp: new Date().toISOString(),
+        },
+      });
+    } catch (err) {
+      console.error('Failed to submit investigate action:', err);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 12,
+        background: '#0f172a',
+        color: '#e2e8f0',
+        fontFamily: 'Tahoma, sans-serif',
+        fontSize: 12,
+      }}
+    >
+      <div style={{ fontWeight: 'bold', marginBottom: 8, color: '#60a5fa' }}>
+        Pick a player to investigate tonight.
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {candidates.map((p) => {
+          const isSelected = pendingSelection === p.playerId;
+          return (
+            <div
+              key={p.playerId}
+              onClick={() => !hasSubmitted && selectInvestigateTarget(p.playerId)}
+              style={{
+                padding: '6px 8px',
+                cursor: hasSubmitted ? 'default' : 'pointer',
+                background: isSelected ? '#1d4ed8' : 'transparent',
+                display: 'flex',
+                justifyContent: 'space-between',
+                borderRadius: 2,
+                marginBottom: 2,
+              }}
+            >
+              <span>{p.displayName}</span>
+            </div>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={handleConfirm}
+        disabled={hasSubmitted || !pendingSelection}
+        style={{ marginTop: 8, padding: '6px 12px' }}
+      >
+        {hasSubmitted ? 'Submitted' : 'Confirm'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/apps/TattleStation/InvestigatePanel.test.jsx
+++ b/apps/web/src/apps/TattleStation/InvestigatePanel.test.jsx
@@ -1,4 +1,4 @@
-import { fireEvent, render, screen } from '@testing-library/react';
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import InvestigatePanel from './InvestigatePanel';
 import useGameStore from '../../stores/gameStore';
@@ -44,16 +44,17 @@ describe('InvestigatePanel', () => {
     expect(screen.getByText('P3')).toBeInTheDocument();
   });
 
-  it('dispatches submitIntent with INVESTIGATE when a target is confirmed', () => {
+  it('dispatches submitIntent with INVESTIGATE when a target is confirmed', async () => {
     setStore({
       selfId: 'p1',
       selfRole: 'WHITE_HAT_HACKER',
+      cycle: 2,
       players: {
         p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
         p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
       },
     });
-    const send = vi.fn();
+    const send = vi.fn().mockResolvedValue(undefined);
 
     renderWithSocket(<InvestigatePanel />, { send });
     fireEvent.click(screen.getByText('P3'));
@@ -70,9 +71,45 @@ describe('InvestigatePanel', () => {
         clientTimestamp: expect.any(String),
       },
     });
+    await waitFor(() =>
+      expect(useGameStore.getState().investigateSubmittedCycle).toBe(2),
+    );
   });
 
-  it('shows "Submitted" when a SUBMIT_NIGHT_ACTION intent is already pending', () => {
+  it('shows "Submitted" when investigateSubmittedCycle matches the current cycle', () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      cycle: 3,
+      investigateSubmittedCycle: 3,
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
+      },
+    });
+
+    renderWithSocket(<InvestigatePanel />);
+    const button = screen.getByRole('button', { name: /submitted/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('does NOT treat a different cycle as submitted (resilient to stale flag)', () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      cycle: 4,
+      investigateSubmittedCycle: 3, // stale from previous night
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
+      },
+    });
+
+    renderWithSocket(<InvestigatePanel />);
+    expect(screen.getByRole('button', { name: /confirm/i })).toBeInTheDocument();
+  });
+
+  it('disables Confirm when no target is selected', () => {
     setStore({
       selfId: 'p1',
       selfRole: 'WHITE_HAT_HACKER',
@@ -80,11 +117,62 @@ describe('InvestigatePanel', () => {
         p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
         p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
       },
-      pendingIntentTypes: ['SUBMIT_NIGHT_ACTION'],
     });
 
     renderWithSocket(<InvestigatePanel />);
-    const button = screen.getByRole('button', { name: /submitted/i });
-    expect(button).toBeDisabled();
+    expect(screen.getByRole('button', { name: /confirm/i })).toBeDisabled();
+  });
+
+  it('renders an empty-state message when no valid targets remain', () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p2: { playerId: 'p2', displayName: 'P2', alive: false, connected: true, team: 'FRIENDS' },
+      },
+    });
+
+    renderWithSocket(<InvestigatePanel />);
+    expect(screen.getByText(/No valid targets available/i)).toBeInTheDocument();
+  });
+
+  it('supports keyboard selection (Enter/Space) for accessibility', () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
+      },
+    });
+
+    renderWithSocket(<InvestigatePanel />);
+    const option = screen.getByText('P3').closest('[role="option"]');
+    expect(option).toHaveAttribute('tabIndex', '0');
+    fireEvent.keyDown(option, { key: 'Enter' });
+    expect(useGameStore.getState().pendingInvestigateSelection).toBe('p3');
+  });
+
+  it('surfaces an inline error when the socket send rejects', async () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      cycle: 1,
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
+      },
+    });
+    const send = vi.fn().mockRejectedValue(new Error('network down'));
+
+    renderWithSocket(<InvestigatePanel />, { send });
+    fireEvent.click(screen.getByText('P3'));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent(/network down/i);
+    });
+    expect(useGameStore.getState().investigateSubmittedCycle).toBeNull();
   });
 });

--- a/apps/web/src/apps/TattleStation/InvestigatePanel.test.jsx
+++ b/apps/web/src/apps/TattleStation/InvestigatePanel.test.jsx
@@ -1,0 +1,90 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import InvestigatePanel from './InvestigatePanel';
+import useGameStore from '../../stores/gameStore';
+import { SocketContext } from '../../lib/SocketContext';
+
+function setStore(patch) {
+  useGameStore.setState({
+    ...useGameStore.getInitialState(),
+    ...patch,
+  });
+}
+
+function renderWithSocket(ui, socket = { send: () => {} }) {
+  return render(
+    <SocketContext.Provider value={socket}>{ui}</SocketContext.Provider>
+  );
+}
+
+describe('InvestigatePanel', () => {
+  beforeEach(() => {
+    useGameStore.setState(useGameStore.getInitialState());
+  });
+
+  it('renders all living players except self (teammates/Friends included)', () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      selfTeam: 'FRIENDS',
+      myTeam: 'FRIENDS',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p2: { playerId: 'p2', displayName: 'P2', alive: true, connected: true, team: 'FRIENDS' },
+        p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
+        p4: { playerId: 'p4', displayName: 'P4', alive: false, connected: true, team: 'FRIENDS' },
+      },
+    });
+
+    renderWithSocket(<InvestigatePanel />);
+
+    expect(screen.queryByText('P1')).not.toBeInTheDocument();
+    expect(screen.queryByText('P4')).not.toBeInTheDocument();
+    expect(screen.getByText('P2')).toBeInTheDocument();
+    expect(screen.getByText('P3')).toBeInTheDocument();
+  });
+
+  it('dispatches submitIntent with INVESTIGATE when a target is confirmed', () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
+      },
+    });
+    const send = vi.fn();
+
+    renderWithSocket(<InvestigatePanel />, { send });
+    fireEvent.click(screen.getByText('P3'));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(send).toHaveBeenCalledWith('submitIntent', {
+      intent: {
+        type: 'SUBMIT_NIGHT_ACTION',
+        payload: {
+          actionType: 'INVESTIGATE',
+          targetPlayerId: 'p3',
+          metadata: {},
+        },
+        clientTimestamp: expect.any(String),
+      },
+    });
+  });
+
+  it('shows "Submitted" when a SUBMIT_NIGHT_ACTION intent is already pending', () => {
+    setStore({
+      selfId: 'p1',
+      selfRole: 'WHITE_HAT_HACKER',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true, team: 'FRIENDS' },
+        p3: { playerId: 'p3', displayName: 'P3', alive: true, connected: true, team: 'HACKERS' },
+      },
+      pendingIntentTypes: ['SUBMIT_NIGHT_ACTION'],
+    });
+
+    renderWithSocket(<InvestigatePanel />);
+    const button = screen.getByRole('button', { name: /submitted/i });
+    expect(button).toBeDisabled();
+  });
+});

--- a/apps/web/src/apps/TattleStation/SystemEventFeed.jsx
+++ b/apps/web/src/apps/TattleStation/SystemEventFeed.jsx
@@ -1,3 +1,5 @@
+import { ROLE_DEFINITIONS } from '@tattletale/shared';
+
 const TEMPLATES = {
   GAME_STARTED: () => 'The game has begun.',
   PLAYER_VOTED_OUT: ({ targetDisplayName } = {}) =>
@@ -10,6 +12,10 @@ const TEMPLATES = {
   MESSAGE_INTEGRITY_COMPROMISED: () => 'A message was tampered with.',
   TEMP_CHANNEL_CREATED: () => 'A new channel opened.',
   PSYCHIC_SIGNAL_RECEIVED: () => 'A psychic signal is coming through.',
+  INVESTIGATION_RESULT: ({ targetDisplayName, targetRoleId } = {}) => {
+    const roleName = ROLE_DEFINITIONS.get(targetRoleId)?.displayName ?? 'Unknown Role';
+    return `You investigated ${targetDisplayName ?? 'a player'}. They are a ${roleName}.`;
+  },
 };
 
 function formatEvent(event) {

--- a/apps/web/src/apps/TattleStation/SystemEventFeed.jsx
+++ b/apps/web/src/apps/TattleStation/SystemEventFeed.jsx
@@ -14,7 +14,7 @@ const TEMPLATES = {
   PSYCHIC_SIGNAL_RECEIVED: () => 'A psychic signal is coming through.',
   INVESTIGATION_RESULT: ({ targetDisplayName, targetRoleId } = {}) => {
     const roleName = ROLE_DEFINITIONS.get(targetRoleId)?.displayName ?? 'Unknown Role';
-    return `You investigated ${targetDisplayName ?? 'a player'}. They are a ${roleName}.`;
+    return `You investigated ${targetDisplayName ?? 'a player'}. Their role: ${roleName}.`;
   },
 };
 

--- a/apps/web/src/apps/TattleStation/SystemEventFeed.test.jsx
+++ b/apps/web/src/apps/TattleStation/SystemEventFeed.test.jsx
@@ -58,6 +58,44 @@ describe('SystemEventFeed', () => {
     expect(screen.getByText(/waiting for results/i)).toBeInTheDocument();
   });
 
+  it('renders INVESTIGATION_RESULT with target display name and role', () => {
+    const events = [
+      {
+        id: 'e1',
+        type: 'INVESTIGATION_RESULT',
+        createdAt: '2026-03-17T00:00:30.000Z',
+        metadata: {
+          type: 'INVESTIGATION_RESULT',
+          targetPlayerId: 'p3',
+          targetDisplayName: 'Eve',
+          targetRoleId: 'HACKER',
+          targetTeam: 'HACKERS',
+        },
+      },
+    ];
+    render(<SystemEventFeed events={events} />);
+    expect(screen.getByText(/You investigated Eve\. They are a Hacker\./i)).toBeInTheDocument();
+  });
+
+  it('renders INVESTIGATION_RESULT with unknown role fallback', () => {
+    const events = [
+      {
+        id: 'e1',
+        type: 'INVESTIGATION_RESULT',
+        createdAt: '2026-03-17T00:00:30.000Z',
+        metadata: {
+          type: 'INVESTIGATION_RESULT',
+          targetPlayerId: 'p3',
+          targetDisplayName: 'Eve',
+          targetRoleId: 'NOT_A_REAL_ROLE',
+          targetTeam: 'HACKERS',
+        },
+      },
+    ];
+    render(<SystemEventFeed events={events} />);
+    expect(screen.getByText(/They are a Unknown Role/i)).toBeInTheDocument();
+  });
+
   it('renders PLAYER_VOTED_OUT without metadata gracefully', () => {
     const events = [
       { id: 'e1', type: 'PLAYER_VOTED_OUT', createdAt: '2026-03-17T00:00:30.000Z' },

--- a/apps/web/src/apps/TattleStation/SystemEventFeed.test.jsx
+++ b/apps/web/src/apps/TattleStation/SystemEventFeed.test.jsx
@@ -74,7 +74,7 @@ describe('SystemEventFeed', () => {
       },
     ];
     render(<SystemEventFeed events={events} />);
-    expect(screen.getByText(/You investigated Eve\. They are a Hacker\./i)).toBeInTheDocument();
+    expect(screen.getByText(/You investigated Eve\. Their role: Hacker\./i)).toBeInTheDocument();
   });
 
   it('renders INVESTIGATION_RESULT with unknown role fallback', () => {
@@ -93,7 +93,7 @@ describe('SystemEventFeed', () => {
       },
     ];
     render(<SystemEventFeed events={events} />);
-    expect(screen.getByText(/They are a Unknown Role/i)).toBeInTheDocument();
+    expect(screen.getByText(/Their role: Unknown Role/i)).toBeInTheDocument();
   });
 
   it('renders PLAYER_VOTED_OUT without metadata gracefully', () => {

--- a/apps/web/src/apps/TattleStation/index.jsx
+++ b/apps/web/src/apps/TattleStation/index.jsx
@@ -1,10 +1,11 @@
-import useGameStore, { selectIsHacker } from '../../stores/gameStore';
+import useGameStore, { selectIsHacker, selectIsWhiteHatHacker } from '../../stores/gameStore';
 import PhaseHeader from './PhaseHeader';
 import PlayerList from './PlayerList';
 import ChannelSidebar from './ChannelSidebar';
 import ChatPanel from './ChatPanel';
 import VotePanel from './VotePanel';
 import NightPanel from './NightPanel';
+import InvestigatePanel from './InvestigatePanel';
 import NightSpectatorView from './NightSpectatorView';
 import SystemEventFeed from './SystemEventFeed';
 
@@ -14,6 +15,7 @@ function TattleStationComponent() {
   const activeChannelId = useGameStore((s) => s.activeChannelId);
   const systemEvents = useGameStore((s) => s.systemEvents);
   const isHacker = useGameStore(selectIsHacker);
+  const isWhiteHatHacker = useGameStore(selectIsWhiteHatHacker);
 
   const showVotePanel = phase === 'DAY_VOTE' && selfAlive;
   const showNightUi = phase === 'NIGHT_ACTIONS' && selfAlive;
@@ -24,8 +26,11 @@ function TattleStationComponent() {
 
   const centerPanel = (() => {
     if (showVotePanel) return <VotePanel />;
-    if (showNightUi)
-      return isHacker ? <NightPanel /> : <NightSpectatorView />;
+    if (showNightUi) {
+      if (isHacker) return <NightPanel />;
+      if (isWhiteHatHacker) return <InvestigatePanel />;
+      return <NightSpectatorView />;
+    }
     if (showSystemEvents) return <SystemEventFeed events={systemEvents} />;
     if (activeChannelId) return <ChatPanel channelId={activeChannelId} />;
     return (

--- a/apps/web/src/stores/gameStore.js
+++ b/apps/web/src/stores/gameStore.js
@@ -36,6 +36,7 @@ const initialState = {
   myTeammates: [],
   hackerNightView: null,
   pendingNightKillSelection: null,
+  pendingInvestigateSelection: null,
 
   // Session slice
   gameId: '',
@@ -174,6 +175,16 @@ const useGameStore = create(
         state.pendingNightKillSelection = null;
       }),
 
+    selectInvestigateTarget: (id) =>
+      set((state) => {
+        state.pendingInvestigateSelection = id;
+      }),
+
+    clearInvestigateSelection: () =>
+      set((state) => {
+        state.pendingInvestigateSelection = null;
+      }),
+
     // --- Session actions ---
 
     setElimination: (cause, cycle) =>
@@ -306,6 +317,7 @@ const useGameStore = create(
         // Clear pending night selection on phase change
         if (previousPhase === 'NIGHT_ACTIONS' && view.phase !== 'NIGHT_ACTIONS') {
           state.pendingNightKillSelection = null;
+          state.pendingInvestigateSelection = null;
         }
 
         // Session slice
@@ -329,6 +341,19 @@ export function selectIsHacker(state) {
   if (state.myTeam !== 'HACKERS') return false;
   const self = state.selfId ? state.players?.[state.selfId] : null;
   return Boolean(self?.alive);
+}
+
+export function selectIsWhiteHatHacker(state) {
+  if (state.selfRole !== 'WHITE_HAT_HACKER') return false;
+  const self = state.selfId ? state.players?.[state.selfId] : null;
+  return Boolean(self?.alive);
+}
+
+export function selectInvestigateCandidates(state) {
+  if (!state.players) return [];
+  return Object.values(state.players).filter(
+    (p) => p.alive && p.playerId !== state.selfId,
+  );
 }
 
 export function selectIsHackerNight(state) {

--- a/apps/web/src/stores/gameStore.js
+++ b/apps/web/src/stores/gameStore.js
@@ -37,6 +37,11 @@ const initialState = {
   hackerNightView: null,
   pendingNightKillSelection: null,
   pendingInvestigateSelection: null,
+  // Cycle number in which the viewer last submitted an INVESTIGATE intent.
+  // Scoped per-cycle because `pendingIntentTypes` is coarse (it only tracks
+  // IntentType, not actionType) and would false-positive if any other
+  // SUBMIT_NIGHT_ACTION is pending (e.g. after a Jealous SWAP_ROLE).
+  investigateSubmittedCycle: null,
 
   // Session slice
   gameId: '',
@@ -185,6 +190,11 @@ const useGameStore = create(
         state.pendingInvestigateSelection = null;
       }),
 
+    markInvestigateSubmitted: (cycle) =>
+      set((state) => {
+        state.investigateSubmittedCycle = cycle;
+      }),
+
     // --- Session actions ---
 
     setElimination: (cause, cycle) =>
@@ -205,6 +215,7 @@ const useGameStore = create(
     syncSessionState: (view) =>
       set((state) => {
         const previousPhase = state.phase;
+        const previousSelfRole = state.selfRole;
 
         // Phase slice
         state.phase = view.phase;
@@ -318,6 +329,17 @@ const useGameStore = create(
         if (previousPhase === 'NIGHT_ACTIONS' && view.phase !== 'NIGHT_ACTIONS') {
           state.pendingNightKillSelection = null;
           state.pendingInvestigateSelection = null;
+          state.investigateSubmittedCycle = null;
+        }
+        // Defense-in-depth: if the viewer's role was swapped away from
+        // WHITE_HAT_HACKER mid-game (e.g. Jealous SWAP_ROLE), drop any stale
+        // investigate selection so it can't leak into a later cycle.
+        if (
+          previousSelfRole === 'WHITE_HAT_HACKER' &&
+          view.myRole !== 'WHITE_HAT_HACKER'
+        ) {
+          state.pendingInvestigateSelection = null;
+          state.investigateSubmittedCycle = null;
         }
 
         // Session slice
@@ -351,9 +373,12 @@ export function selectIsWhiteHatHacker(state) {
 
 export function selectInvestigateCandidates(state) {
   if (!state.players) return [];
-  return Object.values(state.players).filter(
-    (p) => p.alive && p.playerId !== state.selfId,
-  );
+  return Object.values(state.players)
+    .filter((p) => p.alive && p.playerId !== state.selfId)
+    .sort((a, b) => {
+      const nameCmp = (a.displayName ?? '').localeCompare(b.displayName ?? '');
+      return nameCmp !== 0 ? nameCmp : a.playerId.localeCompare(b.playerId);
+    });
 }
 
 export function selectIsHackerNight(state) {


### PR DESCRIPTION
## Summary
- Fixes `ROLE_ACTION_MAP` key (`WHITE_HAT` → `WHITE_HAT_HACKER`) so a player assigned `RoleId.WHITE_HAT_HACKER` passes `validateRoleAction` for `INVESTIGATE`.
- Adds `InvestigatePanel` React component for the White Hat Hacker during `NIGHT_ACTIONS`; routes it from `TattleStation/index.jsx` via a new `selectIsWhiteHatHacker` selector.
- Adds `INVESTIGATION_RESULT` formatter to `SystemEventFeed`, resolving the target role's display name via `ROLE_DEFINITIONS` from `@tattletale/shared`.
- Store: new `pendingInvestigateSelection` slice + `selectInvestigateTarget` / `clearInvestigateSelection` actions.

The server-side resolver, private-event delivery, and target validation (self/dead) were already wired in prior work — only the role-id/action map mismatch blocked end-to-end use.

Closes #79.

## Test plan
- [x] `npm test --workspaces` (server: 149 pass, web: 52 pass, shared: 2 pass)
- [ ] Manual: start a 7+ player game with WHITE_HAT_HACKER enabled, advance to NIGHT_ACTIONS, confirm InvestigatePanel renders for the white hat (and only them), submit INVESTIGATE on a Hacker, confirm the result appears privately in that player's SystemEventFeed after NIGHT_RESOLVE.