### PR TITLE
feat: Add Security Specialist protect action during night phase

### DIFF
--- a/apps/server/src/domain/projections.test.ts
+++ b/apps/server/src/domain/projections.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from 'vitest';
 import { toPlayerSessionView } from './projections.js';
-import { Phase, ChannelType, IntentType, NightActionType, RestrictionType, SessionStatus, SystemEventType, Team } from '@tattletale/shared';
+import { Phase, ChannelType, IntentType, NightActionType, RestrictionType, RoleId, SessionStatus, SystemEventType, Team } from '@tattletale/shared';
 import type { GameState } from './game/types.js';
 import { RestrictionBuilders } from './game/restrictions.js';
 import { buildSessionFromLobby } from './game/session-domain.js';
@@ -199,6 +199,83 @@ describe('toPlayerSessionView', () => {
       const hacker = Object.values(session.players).find((p) => p.team === Team.HACKERS)!.playerId;
       expect(toPlayerSessionView(session, friend).channels.find((c) => c.id === 'hacker')).toBeUndefined();
       expect(toPlayerSessionView(session, hacker).channels.find((c) => c.id === 'hacker')).toBeDefined();
+    });
+  });
+
+  describe('protectNightView discriminator', () => {
+    function makeProtectState(overrides?: Partial<GameState>): GameState {
+      return {
+        gameId: 'game-1',
+        lobbyCode: 'ABC123',
+        status: SessionStatus.ACTIVE,
+        winnerTeam: null,
+        phase: Phase.NIGHT_ACTIONS,
+        cycle: 1,
+        players: {
+          p1: { playerId: 'p1', displayName: 'Alice', alive: true, connected: true, roleId: RoleId.SECURITY_SPECIALIST, team: Team.FRIENDS, permissions: [] },
+          p2: { playerId: 'p2', displayName: 'Bob', alive: true, connected: true, roleId: RoleId.FRIEND, team: Team.FRIENDS, permissions: [] },
+          p3: { playerId: 'p3', displayName: 'Carol', alive: true, connected: true, roleId: RoleId.HACKER, team: Team.HACKERS, permissions: [] },
+        },
+        channels: {
+          global: { id: 'global', type: ChannelType.GLOBAL, members: ['p1', 'p2', 'p3'], locked: false, expiresAt: null },
+        },
+        pendingIntents: [],
+        systemEvents: [],
+        timers: { currentPhaseEndsAt: null, currentPhaseDurationSeconds: 0 },
+        createdAt: '2026-01-01T00:00:00Z',
+        updatedAt: '2026-01-01T00:00:00Z',
+        ...overrides,
+      };
+    }
+
+    it('non-null protectNightView for living Specialist during NIGHT_ACTIONS, with confirmed target after submission', () => {
+      const state = makeProtectState({
+        pendingIntents: [
+          {
+            id: 'i1', playerId: 'p1', type: IntentType.SUBMIT_NIGHT_ACTION,
+            payload: { actionType: NightActionType.PROTECT, targetPlayerId: 'p2', metadata: {} },
+            phase: Phase.NIGHT_ACTIONS, cycle: 1, createdAt: '',
+          },
+        ],
+      });
+      const view = toPlayerSessionView(state, 'p1');
+      expect(view.protectNightView).toEqual({ confirmedTarget: 'p2' });
+    });
+
+    it('confirmedTarget is null when Specialist has not submitted yet', () => {
+      const view = toPlayerSessionView(makeProtectState(), 'p1');
+      expect(view.protectNightView).toEqual({ confirmedTarget: null });
+    });
+
+    it('null protectNightView for non-Specialist roles', () => {
+      const state = makeProtectState();
+      expect(toPlayerSessionView(state, 'p2').protectNightView).toBeNull();
+      expect(toPlayerSessionView(state, 'p3').protectNightView).toBeNull();
+    });
+
+    it('null protectNightView for dead Specialist', () => {
+      const state = makeProtectState();
+      state.players.p1.alive = false;
+      expect(toPlayerSessionView(state, 'p1').protectNightView).toBeNull();
+    });
+
+    it('null protectNightView outside NIGHT_ACTIONS', () => {
+      const state = makeProtectState({ phase: Phase.DAY_OPEN });
+      expect(toPlayerSessionView(state, 'p1').protectNightView).toBeNull();
+    });
+
+    it('ignores PROTECT intents from prior cycles', () => {
+      const state = makeProtectState({
+        cycle: 2,
+        pendingIntents: [
+          {
+            id: 'i1', playerId: 'p1', type: IntentType.SUBMIT_NIGHT_ACTION,
+            payload: { actionType: NightActionType.PROTECT, targetPlayerId: 'p2', metadata: {} },
+            phase: Phase.NIGHT_ACTIONS, cycle: 1, createdAt: '',
+          },
+        ],
+      });
+      expect(toPlayerSessionView(state, 'p1').protectNightView).toEqual({ confirmedTarget: null });
     });
   });
 

--- a/apps/server/src/domain/projections.ts
+++ b/apps/server/src/domain/projections.ts
@@ -1,4 +1,4 @@
-import { ChannelType, IntentType, NightActionType, Phase, RestrictionType, Team, type LobbyView, type PlayerSessionView, type HackerNightView, type ViewerRestriction } from '@tattletale/shared';
+import { ChannelType, IntentType, NightActionType, Phase, RestrictionType, RoleId, Team, type LobbyView, type PlayerSessionView, type HackerNightView, type ProtectNightView, type ViewerRestriction } from '@tattletale/shared';
 
 import type { GameState, NightActionIntentPayload, Restriction, VoteIntentPayload } from './game/types.js';
 import type { LobbyState } from './lobby/types.js';
@@ -128,6 +128,26 @@ export function toPlayerSessionView(session: GameState, playerId: string): Playe
     }
   }
 
+  // Security-Specialist-scoped night fields. Mirrors hackerNightView discriminator:
+  // non-null iff viewer is a living SECURITY_SPECIALIST AND phase is NIGHT_ACTIONS.
+  let protectNightView: ProtectNightView | null = null;
+  if (
+    !!player?.alive
+    && player.roleId === RoleId.SECURITY_SPECIALIST
+    && session.phase === Phase.NIGHT_ACTIONS
+  ) {
+    let confirmedTarget: string | null = null;
+    for (const intent of session.pendingIntents) {
+      if (intent.type !== IntentType.SUBMIT_NIGHT_ACTION) continue;
+      if (intent.cycle !== session.cycle) continue;
+      if (intent.playerId !== playerId) continue;
+      const payload = intent.payload as NightActionIntentPayload;
+      if (payload.actionType !== NightActionType.PROTECT) continue;
+      confirmedTarget = payload.targetPlayerId ?? null;
+    }
+    protectNightView = { confirmedTarget };
+  }
+
   return {
     gameId: session.gameId,
     lobbyCode: session.lobbyCode,
@@ -181,6 +201,7 @@ export function toPlayerSessionView(session: GameState, playerId: string): Playe
     myTeam: player?.team ?? ('FRIENDS' as any),
     myTeammates,
     hackerNightView,
+    protectNightView,
     myRestrictions: projectRestrictions(
       session.restrictions ?? [],
       playerId,

--- a/apps/web/src/apps/TattleStation/ProtectPanel.jsx
+++ b/apps/web/src/apps/TattleStation/ProtectPanel.jsx
@@ -1,0 +1,89 @@
+import useGameStore from '../../stores/gameStore';
+import { useSocket } from '../../lib/SocketContext';
+
+export default function ProtectPanel() {
+  const socket = useSocket();
+  const players = useGameStore((s) => s.players);
+  const selfId = useGameStore((s) => s.selfId);
+  const protectNightView = useGameStore((s) => s.protectNightView);
+  const pendingSelection = useGameStore((s) => s.pendingProtectSelection);
+  const selectProtectTarget = useGameStore((s) => s.selectProtectTarget);
+
+  if (!protectNightView) return null;
+
+  const confirmedTarget = protectNightView.confirmedTarget ?? null;
+  const hasSubmitted = confirmedTarget !== null;
+
+  const candidates = Object.values(players).filter(
+    (p) => p.alive && p.playerId !== selfId,
+  );
+
+  const handleConfirm = async () => {
+    if (!pendingSelection || hasSubmitted) return;
+    try {
+      await socket.send('submitIntent', {
+        intent: {
+          type: 'SUBMIT_NIGHT_ACTION',
+          payload: {
+            actionType: 'PROTECT',
+            targetPlayerId: pendingSelection,
+            metadata: {},
+          },
+          clientTimestamp: new Date().toISOString(),
+        },
+      });
+    } catch (err) {
+      console.error('Failed to submit protect action:', err);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 12,
+        background: '#1e293b',
+        color: '#e2e8f0',
+        fontFamily: 'Tahoma, sans-serif',
+        fontSize: 12,
+      }}
+    >
+      <div style={{ fontWeight: 'bold', marginBottom: 8, color: '#10b981' }}>
+        Pick a player to protect tonight.
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {candidates.map((p) => {
+          const isSelected =
+            pendingSelection === p.playerId || confirmedTarget === p.playerId;
+          return (
+            <div
+              key={p.playerId}
+              onClick={() => !hasSubmitted && selectProtectTarget(p.playerId)}
+              style={{
+                padding: '6px 8px',
+                cursor: hasSubmitted ? 'default' : 'pointer',
+                background: isSelected ? '#047857' : 'transparent',
+                display: 'flex',
+                justifyContent: 'space-between',
+                borderRadius: 2,
+                marginBottom: 2,
+              }}
+            >
+              <span>{p.displayName}</span>
+            </div>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={handleConfirm}
+        disabled={hasSubmitted || !pendingSelection}
+        style={{ marginTop: 8, padding: '6px 12px' }}
+      >
+        {hasSubmitted ? 'Submitted' : 'Confirm'}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/apps/TattleStation/ProtectPanel.test.jsx
+++ b/apps/web/src/apps/TattleStation/ProtectPanel.test.jsx
@@ -1,0 +1,93 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import ProtectPanel from './ProtectPanel';
+import useGameStore from '../../stores/gameStore';
+import { SocketContext } from '../../lib/SocketContext';
+
+function setStore(patch) {
+  useGameStore.setState({
+    ...useGameStore.getInitialState(),
+    ...patch,
+  });
+}
+
+function renderWithSocket(ui, socket = { send: () => {} }) {
+  return render(
+    <SocketContext.Provider value={socket}>{ui}</SocketContext.Provider>
+  );
+}
+
+describe('ProtectPanel', () => {
+  beforeEach(() => {
+    useGameStore.setState(useGameStore.getInitialState());
+  });
+
+  it('returns null when protectNightView is null', () => {
+    setStore({ protectNightView: null });
+    const { container } = renderWithSocket(<ProtectPanel />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('renders living non-self candidates', () => {
+    setStore({
+      selfId: 'p1',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true },
+        p2: { playerId: 'p2', displayName: 'P2', alive: true, connected: true },
+        p3: { playerId: 'p3', displayName: 'P3', alive: false, connected: true },
+        p4: { playerId: 'p4', displayName: 'P4', alive: true, connected: true },
+      },
+      protectNightView: { confirmedTarget: null },
+    });
+
+    renderWithSocket(<ProtectPanel />);
+
+    expect(screen.queryByText('P1')).not.toBeInTheDocument(); // self
+    expect(screen.queryByText('P3')).not.toBeInTheDocument(); // dead
+    expect(screen.getByText('P2')).toBeInTheDocument();
+    expect(screen.getByText('P4')).toBeInTheDocument();
+  });
+
+  it('dispatches submitIntent with PROTECT when a target is confirmed', () => {
+    setStore({
+      selfId: 'p1',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true },
+        p2: { playerId: 'p2', displayName: 'P2', alive: true, connected: true },
+      },
+      protectNightView: { confirmedTarget: null },
+    });
+    const send = vi.fn();
+
+    renderWithSocket(<ProtectPanel />, { send });
+    fireEvent.click(screen.getByText('P2'));
+    fireEvent.click(screen.getByRole('button', { name: /confirm/i }));
+
+    expect(send).toHaveBeenCalledWith('submitIntent', {
+      intent: {
+        type: 'SUBMIT_NIGHT_ACTION',
+        payload: {
+          actionType: 'PROTECT',
+          targetPlayerId: 'p2',
+          metadata: {},
+        },
+        clientTimestamp: expect.any(String),
+      },
+    });
+  });
+
+  it('disables the button and shows Submitted after confirmation (rehydration)', () => {
+    setStore({
+      selfId: 'p1',
+      players: {
+        p1: { playerId: 'p1', displayName: 'P1', alive: true, connected: true },
+        p2: { playerId: 'p2', displayName: 'P2', alive: true, connected: true },
+      },
+      protectNightView: { confirmedTarget: 'p2' },
+    });
+
+    renderWithSocket(<ProtectPanel />);
+    const button = screen.getByRole('button', { name: /submitted/i });
+    expect(button).toBeDisabled();
+  });
+});

--- a/apps/web/src/apps/TattleStation/index.jsx
+++ b/apps/web/src/apps/TattleStation/index.jsx
@@ -1,4 +1,4 @@
-import useGameStore, { selectIsHacker, selectIsWhiteHatHacker } from '../../stores/gameStore';
+import useGameStore, { selectIsHacker, selectIsWhiteHatHacker, selectIsSecuritySpecialist } from '../../stores/gameStore';
 import PhaseHeader from './PhaseHeader';
 import PlayerList from './PlayerList';
 import ChannelSidebar from './ChannelSidebar';
@@ -6,6 +6,7 @@ import ChatPanel from './ChatPanel';
 import VotePanel from './VotePanel';
 import NightPanel from './NightPanel';
 import InvestigatePanel from './InvestigatePanel';
+import ProtectPanel from './ProtectPanel';
 import NightSpectatorView from './NightSpectatorView';
 import SystemEventFeed from './SystemEventFeed';
 
@@ -16,6 +17,7 @@ function TattleStationComponent() {
   const systemEvents = useGameStore((s) => s.systemEvents);
   const isHacker = useGameStore(selectIsHacker);
   const isWhiteHatHacker = useGameStore(selectIsWhiteHatHacker);
+  const isSecuritySpecialist = useGameStore(selectIsSecuritySpecialist);
 
   const showVotePanel = phase === 'DAY_VOTE' && selfAlive;
   const showNightUi = phase === 'NIGHT_ACTIONS' && selfAlive;
@@ -29,6 +31,7 @@ function TattleStationComponent() {
     if (showNightUi) {
       if (isHacker) return <NightPanel />;
       if (isWhiteHatHacker) return <InvestigatePanel />;
+      if (isSecuritySpecialist) return <ProtectPanel />;
       return <NightSpectatorView />;
     }
     if (showSystemEvents) return <SystemEventFeed events={systemEvents} />;

--- a/apps/web/src/stores/gameStore.js
+++ b/apps/web/src/stores/gameStore.js
@@ -43,6 +43,10 @@ const initialState = {
   // SUBMIT_NIGHT_ACTION is pending (e.g. after a Jealous SWAP_ROLE).
   investigateSubmittedCycle: null,
 
+  // Protect slice (Security-Specialist-scoped)
+  protectNightView: null,
+  pendingProtectSelection: null,
+
   // Session slice
   gameId: '',
   lobbyCode: '',
@@ -195,6 +199,19 @@ const useGameStore = create(
         state.investigateSubmittedCycle = cycle;
       }),
 
+    // --- Protect actions ---
+
+    selectProtectTarget: (id) =>
+      set((state) => {
+        if (state.protectNightView?.confirmedTarget !== null && state.protectNightView?.confirmedTarget !== undefined) return;
+        state.pendingProtectSelection = id;
+      }),
+
+    clearProtectSelection: () =>
+      set((state) => {
+        state.pendingProtectSelection = null;
+      }),
+
     // --- Session actions ---
 
     setElimination: (cause, cycle) =>
@@ -325,11 +342,13 @@ const useGameStore = create(
         state.myTeam = view.myTeam;
         state.myTeammates = view.myTeammates ?? [];
         state.hackerNightView = view.hackerNightView ?? null;
+        state.protectNightView = view.protectNightView ?? null;
         // Clear pending night selection on phase change
         if (previousPhase === 'NIGHT_ACTIONS' && view.phase !== 'NIGHT_ACTIONS') {
           state.pendingNightKillSelection = null;
           state.pendingInvestigateSelection = null;
           state.investigateSubmittedCycle = null;
+          state.pendingProtectSelection = null;
         }
         // Defense-in-depth: if the viewer's role was swapped away from
         // WHITE_HAT_HACKER mid-game (e.g. Jealous SWAP_ROLE), drop any stale
@@ -340,6 +359,13 @@ const useGameStore = create(
         ) {
           state.pendingInvestigateSelection = null;
           state.investigateSubmittedCycle = null;
+        }
+        // Same defense-in-depth for SECURITY_SPECIALIST role swaps.
+        if (
+          previousSelfRole === 'SECURITY_SPECIALIST' &&
+          view.myRole !== 'SECURITY_SPECIALIST'
+        ) {
+          state.pendingProtectSelection = null;
         }
 
         // Session slice
@@ -367,6 +393,12 @@ export function selectIsHacker(state) {
 
 export function selectIsWhiteHatHacker(state) {
   if (state.selfRole !== 'WHITE_HAT_HACKER') return false;
+  const self = state.selfId ? state.players?.[state.selfId] : null;
+  return Boolean(self?.alive);
+}
+
+export function selectIsSecuritySpecialist(state) {
+  if (state.selfRole !== 'SECURITY_SPECIALIST') return false;
   const self = state.selfId ? state.players?.[state.selfId] : null;
   return Boolean(self?.alive);
 }

--- a/packages/shared/src/contracts/views.ts
+++ b/packages/shared/src/contracts/views.ts
@@ -154,6 +154,11 @@ export interface HackerNightView {
   confirmedTarget: string | null;
 }
 
+export interface ProtectNightView {
+  /** Viewer's own confirmed PROTECT target for the current cycle, if submitted. */
+  confirmedTarget: string | null;
+}
+
 export interface PlayerSessionView {
   gameId: string;
   lobbyCode: string;
@@ -177,6 +182,12 @@ export interface PlayerSessionView {
    * branches in the contract carry hacker-night meaning.
    */
   hackerNightView: HackerNightView | null;
+  /**
+   * Security-Specialist-only night state. Non-null iff viewer is a living
+   * SECURITY_SPECIALIST AND phase is NIGHT_ACTIONS. Single discriminator —
+   * clients render ProtectPanel iff this is non-null.
+   */
+  protectNightView: ProtectNightView | null;
   /**
    * Active communication restrictions affecting this viewer. Covert
    * restrictions (MONITORED) are always omitted. Populated by the


### PR DESCRIPTION
## Summary
Implements the protect action for the Security Specialist role, allowing them to select and confirm a target to protect during the night phase.

## Changes
- **Backend**: Added `ProtectNightView` projection logic in `projections.ts` to surface the confirmed protect target
- **Frontend**: 
  - New `ProtectPanel` component for selecting and confirming protect targets
  - Integrated into `TattleStation` to show when Security Specialist is alive during `NIGHT_ACTIONS` phase
  - Updated `gameStore` with protect-specific state and actions
- **Contracts**: Added `ProtectNightView` type definition in shared views contract

## Test Plan
- [ ] Security Specialist can see and interact with ProtectPanel during night phase
- [ ] Can select a target from living players (excluding self)
- [ ] Selection is reflected in the UI
- [ ] Confirmed protect action is submitted to server
- [ ] UI correctly disables interaction after submission
- [ ] Tests for ProtectPanel component pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)