### PR TITLE
feat: Extrovert multi-target invite (#81) + The Boss override (#85)

### DIFF
--- a/apps/server/src/domain/game/runtime-domain.test.ts
+++ b/apps/server/src/domain/game/runtime-domain.test.ts
@@ -340,6 +340,11 @@ describe('runtime-domain', () => {
       const session = buildSessionFromLobby(lobby, 'game-1', '2026-03-17T00:00:00.000Z');
       initializeSessionRuntime(session, DEFAULT_LOBBY_SETTINGS, '2026-03-17T00:00:00.000Z', () => 0);
       session.phase = Phase.NIGHT_ACTIONS;
+      // Strip THE_BOSS so plurality-voting tests are not perturbed by the
+      // override path (#85). The Boss-specific tests below re-assign the role.
+      for (const p of Object.values(session.players)) {
+        if (p.roleId === RoleId.THE_BOSS) p.roleId = RoleId.HACKER;
+      }
       return { lobby, session };
     }
 
@@ -485,6 +490,68 @@ describe('runtime-domain', () => {
       submitKill(session, h2, f1);
       expect(resolveHackerKillTargetForTest(session)).toBe(f1);
     });
+
+    it("The Boss's target overrides plurality (#85)", () => {
+      const { session } = setupNightSession();
+      const [h1, h2, h3] = hackersOf(session);
+      const [f1, f2] = friendsOf(session);
+      // Need at least 3 hackers to demonstrate override; setup uses 2. Promote a friend.
+      if (!h3) {
+        session.players[f2].team = Team.HACKERS;
+      }
+      const livingHackers = Object.values(session.players)
+        .filter((p) => p.alive && p.team === Team.HACKERS).map((p) => p.playerId);
+      const [b, ...rest] = livingHackers;
+      session.players[b].roleId = RoleId.THE_BOSS;
+      // Pick a non-Hacker target list. f1 stays Friend.
+      const friendsAlive = Object.values(session.players).filter((p) => p.alive && p.team === Team.FRIENDS).map((p) => p.playerId);
+      const targetA = friendsAlive[0];
+      const targetB = friendsAlive[1] ?? friendsAlive[0];
+      // Two non-Boss hackers vote A; Boss votes B. Boss wins.
+      for (const r of rest) submitKill(session, r, targetA);
+      submitKill(session, b, targetB);
+      expect(resolveHackerKillTargetForTest(session)).toBe(targetB);
+      // Sanity: ensure rest size is at least 1 so plurality would have differed.
+      expect(rest.length).toBeGreaterThanOrEqual(1);
+      void h1; void h2;
+    });
+
+    it('falls back to plurality when The Boss abstains', () => {
+      const { session } = setupNightSession();
+      const [h1, h2] = hackersOf(session);
+      const [f1, f2] = friendsOf(session);
+      // Promote a friend so we have 3 living hackers and plurality is meaningful
+      // when the Boss does not submit.
+      session.players[f2].team = Team.HACKERS;
+      session.players[h1].roleId = RoleId.THE_BOSS;
+      // Boss abstains; the two non-Boss hackers both vote f1 → plurality wins.
+      submitKill(session, h2, f1);
+      submitKill(session, f2, f1);
+      expect(resolveHackerKillTargetForTest(session)).toBe(f1);
+    });
+
+    it('falls back to plurality when The Boss is dead', () => {
+      const { session } = setupNightSession();
+      const [h1, h2] = hackersOf(session);
+      const [f1] = friendsOf(session);
+      session.players[h1].roleId = RoleId.THE_BOSS;
+      session.players[h1].alive = false;
+      // With Boss dead, only h2 is a living Hacker → lone-hacker plurality.
+      submitKill(session, h2, f1);
+      expect(resolveHackerKillTargetForTest(session)).toBe(f1);
+    });
+
+    it("falls back to plurality when The Boss's target is invalid (e.g. fellow Hacker)", () => {
+      const { session } = setupNightSession();
+      const [h1, h2] = hackersOf(session);
+      const [f1, f2] = friendsOf(session);
+      session.players[f2].team = Team.HACKERS;
+      session.players[h1].roleId = RoleId.THE_BOSS;
+      submitKill(session, h1, h2); // invalid: targets another Hacker
+      submitKill(session, h2, f1);
+      submitKill(session, f2, f1);
+      expect(resolveHackerKillTargetForTest(session)).toBe(f1);
+    });
   });
 
   describe('NIGHT_ACTIONS → NIGHT_RESOLVE', () => {
@@ -494,6 +561,10 @@ describe('runtime-domain', () => {
       initializeSessionRuntime(session, DEFAULT_LOBBY_SETTINGS, now, () => 0);
       session.phase = Phase.NIGHT_ACTIONS;
       session.timers.currentPhaseEndsAt = '2026-03-17T00:00:30.000Z';
+      // Strip THE_BOSS so plurality-tie tests are not perturbed by Boss override (#85).
+      for (const p of Object.values(session.players)) {
+        if (p.roleId === RoleId.THE_BOSS) p.roleId = RoleId.HACKER;
+      }
       return { lobby, session };
     }
 
@@ -670,6 +741,11 @@ describe('runtime-domain', () => {
       initializeSessionRuntime(session, DEFAULT_LOBBY_SETTINGS, '2026-03-17T00:00:00.000Z', () => 0);
       session.phase = Phase.NIGHT_ACTIONS;
       session.timers.currentPhaseEndsAt = '2026-03-17T00:00:30.000Z';
+      // Strip THE_BOSS so plurality-voting tests are not perturbed by the
+      // override path (#85). Boss-specific tests can re-assign the role.
+      for (const p of Object.values(session.players)) {
+        if (p.roleId === RoleId.THE_BOSS) p.roleId = RoleId.HACKER;
+      }
       return { lobby, session };
     }
 
@@ -788,6 +864,53 @@ describe('runtime-domain', () => {
       expect(tempChannels[0].locked).toBe(false);
       const ev = session.systemEvents.find((e) => e.type === SystemEventType.TEMP_CHANNEL_CREATED);
       expect(ev).toBeDefined();
+    });
+
+    it('Tier 5 CREATE_TEMP_CHAT (multi-target) invites every selected player and filters dead/self/duplicates', () => {
+      const { lobby, session } = buildNightSession();
+      const [f1, f2, f3] = friendIds(session);
+      // Mark a fourth player as dead to confirm filtering.
+      const allFriends = friendIds(session);
+      const deadId = allFriends[3];
+      session.players[deadId].alive = false;
+
+      appendIntent(session, {
+        playerId: f1, type: IntentType.SUBMIT_NIGHT_ACTION,
+        payload: {
+          actionType: NightActionType.CREATE_TEMP_CHAT,
+          targetPlayerId: null,
+          targetPlayerIds: [f2, f3, f1, f2, deadId],
+          metadata: {},
+        },
+        phase: Phase.NIGHT_ACTIONS, cycle: session.cycle, createdAt: '2026-03-17T00:00:10.000Z',
+      });
+
+      reconcileSessionRuntime(session, lobby, DEFAULT_LOBBY_SETTINGS, '2026-03-17T00:00:31.000Z');
+
+      const tempChannels = Object.values(session.channels).filter((c) => c.type === ChannelType.TEMP);
+      expect(tempChannels).toHaveLength(1);
+      expect(tempChannels[0].members.sort()).toEqual([f1, f2, f3].sort());
+    });
+
+    it('Tier 5 CREATE_TEMP_CHAT (multi-target) creates no channel when every invitee is invalid', () => {
+      const { lobby, session } = buildNightSession();
+      const [f1] = friendIds(session);
+
+      appendIntent(session, {
+        playerId: f1, type: IntentType.SUBMIT_NIGHT_ACTION,
+        payload: {
+          actionType: NightActionType.CREATE_TEMP_CHAT,
+          targetPlayerId: null,
+          targetPlayerIds: [f1],
+          metadata: {},
+        },
+        phase: Phase.NIGHT_ACTIONS, cycle: session.cycle, createdAt: '2026-03-17T00:00:10.000Z',
+      });
+
+      reconcileSessionRuntime(session, lobby, DEFAULT_LOBBY_SETTINGS, '2026-03-17T00:00:31.000Z');
+
+      expect(Object.values(session.channels).some((c) => c.type === ChannelType.TEMP)).toBe(false);
+      expect(session.systemEvents.some((e) => e.type === SystemEventType.TEMP_CHANNEL_CREATED)).toBe(false);
     });
 
     it('Tier 5 CHANNEL_LOCK sets locked=true and appends a LOCKED restriction expiring at DAY_RESOLVE', () => {

--- a/apps/server/src/domain/game/runtime-domain.ts
+++ b/apps/server/src/domain/game/runtime-domain.ts
@@ -413,17 +413,28 @@ export function resolveNightActions(
     if (!submitter || !submitter.alive) continue;
 
     if (intent.payload.actionType === NightActionType.CREATE_TEMP_CHAT) {
-      const targetId = intent.payload.targetPlayerId;
-      if (!targetId || targetId === intent.playerId) continue;
-      const targetPlayer = session.players[targetId];
-      if (!targetPlayer || !targetPlayer.alive) continue;
+      // Extrovert may invite any number of players. Accept the new
+      // `targetPlayerIds` array; fall back to legacy single `targetPlayerId`
+      // for backward compat with intents persisted before #81.
+      const rawIds = intent.payload.targetPlayerIds
+        ?? (intent.payload.targetPlayerId ? [intent.payload.targetPlayerId] : []);
+      const filtered: string[] = [];
+      const seen = new Set<string>([intent.playerId]);
+      for (const id of rawIds) {
+        if (!id || seen.has(id)) continue;
+        const p = session.players[id];
+        if (!p || !p.alive) continue;
+        seen.add(id);
+        filtered.push(id);
+      }
+      if (filtered.length === 0) continue;
 
       const channelId = `temp-${intent.id}`;
       if (session.channels[channelId]) continue;
       const newChannel: ChannelState = {
         id: channelId,
         type: ChannelType.TEMP,
-        members: [intent.playerId, targetId],
+        members: [intent.playerId, ...filtered],
         locked: false,
         expiresAt: Phase.DAY_RESOLVE,
       };
@@ -808,6 +819,24 @@ function resolveHackerKillTarget(session: GameState): string | null {
         targetPlayerId: payload.targetPlayerId ?? null,
         createdAt: intent.createdAt,
       });
+    }
+  }
+
+  // The Boss override (#85): if a living Boss submitted a valid kill target,
+  // it overrides plurality. If the Boss abstains or didn't submit, fall through
+  // to normal plurality voting below.
+  const bossPlayer = livingHackers.find((p) => p.roleId === RoleId.THE_BOSS);
+  if (bossPlayer) {
+    const bossSubmission = latestPerHacker.get(bossPlayer.playerId);
+    const bossTarget = bossSubmission?.targetPlayerId ?? null;
+    if (bossTarget) {
+      const bossTargetPlayer = session.players[bossTarget];
+      const bossTargetValid =
+        bossTarget !== bossPlayer.playerId
+        && bossTargetPlayer !== undefined
+        && bossTargetPlayer.alive
+        && bossTargetPlayer.team !== Team.HACKERS;
+      if (bossTargetValid) return bossTarget;
     }
   }
 

--- a/apps/server/src/domain/game/types.ts
+++ b/apps/server/src/domain/game/types.ts
@@ -45,6 +45,8 @@ export interface VoteIntentPayload {
 export interface NightActionIntentPayload {
   actionType: NightActionType;
   targetPlayerId: string | null;
+  /** Multi-target list. Currently only consumed by CREATE_TEMP_CHAT (Extrovert). */
+  targetPlayerIds?: string[] | null;
   targetChannelId?: string;
   metadata: Record<string, unknown>;
 }

--- a/apps/server/src/domain/projections.test.ts
+++ b/apps/server/src/domain/projections.test.ts
@@ -143,7 +143,10 @@ describe('toPlayerSessionView', () => {
         createdAt: '2026-03-17T00:00:10.000Z',
       });
       const view = toPlayerSessionView(session, h1);
-      expect(view.hackerNightView).toEqual({ tally: { [friend]: 1 }, confirmedTarget: friend });
+      const bossId = Object.values(session.players).find(
+        (p) => p.alive && p.team === Team.HACKERS && p.roleId === RoleId.THE_BOSS,
+      )?.playerId ?? null;
+      expect(view.hackerNightView).toEqual({ tally: { [friend]: 1 }, confirmedTarget: friend, bossPlayerId: bossId });
       expect(view.myTeammates).toEqual([h2]);
     });
 
@@ -180,6 +183,7 @@ describe('toPlayerSessionView', () => {
       expect(view.hackerNightView).not.toBeNull();
       expect(view.hackerNightView!.tally).toEqual({});
       expect(view.hackerNightView!.confirmedTarget).toBeNull();
+      expect(typeof view.hackerNightView!.bossPlayerId === 'string' || view.hackerNightView!.bossPlayerId === null).toBe(true);
     });
 
     it('passes typed SystemEventMetadata through', () => {

--- a/apps/server/src/domain/projections.ts
+++ b/apps/server/src/domain/projections.ts
@@ -1,4 +1,4 @@
-import { ChannelType, IntentType, NightActionType, Phase, RestrictionType, RoleId, Team, type LobbyView, type PlayerSessionView, type HackerNightView, type ProtectNightView, type ViewerRestriction } from '@tattletale/shared';
+import { ChannelType, IntentType, NightActionType, Phase, RestrictionType, RoleId, Team, type LobbyView, type PlayerSessionView, type HackerNightView, type ProtectNightView, type ExtrovertNightView, type ViewerRestriction } from '@tattletale/shared';
 
 import type { GameState, NightActionIntentPayload, Restriction, VoteIntentPayload } from './game/types.js';
 import type { LobbyState } from './lobby/types.js';
@@ -124,7 +124,14 @@ export function toPlayerSessionView(session: GameState, playerId: string): Playe
         if (intent.playerId === playerId) confirmedTarget = target;
       }
 
-      hackerNightView = { tally, confirmedTarget };
+      // Surface the living Boss's player id (if any) so Hackers know whose
+      // selection will override plurality (#85). Null if no Boss is alive.
+      const livingBoss = Object.values(session.players).find(
+        (p) => p.alive && p.team === Team.HACKERS && p.roleId === RoleId.THE_BOSS,
+      );
+      const bossPlayerId = livingBoss?.playerId ?? null;
+
+      hackerNightView = { tally, confirmedTarget, bossPlayerId };
     }
   }
 
@@ -146,6 +153,27 @@ export function toPlayerSessionView(session: GameState, playerId: string): Playe
       confirmedTarget = payload.targetPlayerId ?? null;
     }
     protectNightView = { confirmedTarget };
+  }
+
+  // Extrovert-scoped night fields. Mirrors protectNightView discriminator:
+  // non-null iff viewer is a living EXTROVERT AND phase is NIGHT_ACTIONS.
+  let extrovertNightView: ExtrovertNightView | null = null;
+  if (
+    !!player?.alive
+    && player.roleId === RoleId.EXTROVERT
+    && session.phase === Phase.NIGHT_ACTIONS
+  ) {
+    let confirmedTargetIds: string[] | null = null;
+    for (const intent of session.pendingIntents) {
+      if (intent.type !== IntentType.SUBMIT_NIGHT_ACTION) continue;
+      if (intent.cycle !== session.cycle) continue;
+      if (intent.playerId !== playerId) continue;
+      const payload = intent.payload as NightActionIntentPayload;
+      if (payload.actionType !== NightActionType.CREATE_TEMP_CHAT) continue;
+      confirmedTargetIds = payload.targetPlayerIds
+        ?? (payload.targetPlayerId ? [payload.targetPlayerId] : []);
+    }
+    extrovertNightView = { confirmedTargetIds };
   }
 
   return {
@@ -202,6 +230,7 @@ export function toPlayerSessionView(session: GameState, playerId: string): Playe
     myTeammates,
     hackerNightView,
     protectNightView,
+    extrovertNightView,
     myRestrictions: projectRestrictions(
       session.restrictions ?? [],
       playerId,

--- a/apps/server/src/transport/ws-message-handler.ts
+++ b/apps/server/src/transport/ws-message-handler.ts
@@ -196,9 +196,11 @@ function validateNightActionTarget(
       return { valid: true };
     }
     case NightActionType.CREATE_TEMP_CHAT: {
-      if (!targetId || targetId === actorId) return { valid: false, reason: 'Target must be a living player other than yourself.' };
-      const target = session.players[targetId];
-      if (!target || !target.alive) return { valid: false, reason: 'Target must be a living player.' };
+      // Validation lives in the SUBMIT_NIGHT_ACTION branch (multi-target via
+      // targetPlayerIds). This switch arm never sees CREATE_TEMP_CHAT — kept
+      // as a defensive no-op so the switch is exhaustive.
+      void actor;
+      void targetId;
       return { valid: true };
     }
     case NightActionType.CHANNEL_LOCK: {
@@ -904,15 +906,37 @@ export async function handleSubmitIntent(
       }
 
       // Per-action-type target validation.
-      // For CHANNEL_LOCK, prefer targetChannelId; fall back to targetPlayerId for backward
-      // compat with in-flight payloads. TODO: remove fallback once clients migrate. Paired
-      // sites: ws-message-handler.ts ~L199 (validator) and runtime-domain.ts ~L438 (resolver).
-      const resolvedTargetId = actionType === NightActionType.CHANNEL_LOCK
-        ? (nightPayload.targetChannelId ?? nightPayload.targetPlayerId)
-        : nightPayload.targetPlayerId;
-      const targetValidation = validateNightActionTarget(session, actorId, actionType, resolvedTargetId);
-      if (!targetValidation.valid) {
-        return fail('INVALID_TARGET', targetValidation.reason);
+      // CREATE_TEMP_CHAT (Extrovert, #81): validates a multi-target list inline rather
+      // than via validateNightActionTarget, which is single-target only.
+      if (actionType === NightActionType.CREATE_TEMP_CHAT) {
+        const ids = Array.isArray(nightPayload.targetPlayerIds)
+          ? nightPayload.targetPlayerIds
+          : (nightPayload.targetPlayerId ? [nightPayload.targetPlayerId] : []);
+        if (!ids.length) {
+          return fail('INVALID_TARGET', 'CREATE_TEMP_CHAT requires at least one invitee.');
+        }
+        const seen = new Set<string>();
+        for (const id of ids) {
+          if (typeof id !== 'string' || !id || id === actorId || seen.has(id)) {
+            return fail('INVALID_TARGET', 'Invitees must be distinct living players other than yourself.');
+          }
+          seen.add(id);
+          const target = session.players[id];
+          if (!target || !target.alive) {
+            return fail('INVALID_TARGET', 'Invitees must be living players.');
+          }
+        }
+      } else {
+        // For CHANNEL_LOCK, prefer targetChannelId; fall back to targetPlayerId for backward
+        // compat with in-flight payloads. TODO: remove fallback once clients migrate. Paired
+        // sites: ws-message-handler.ts ~L199 (validator) and runtime-domain.ts ~L438 (resolver).
+        const resolvedTargetId = actionType === NightActionType.CHANNEL_LOCK
+          ? (nightPayload.targetChannelId ?? nightPayload.targetPlayerId)
+          : nightPayload.targetPlayerId;
+        const targetValidation = validateNightActionTarget(session, actorId, actionType, resolvedTargetId);
+        if (!targetValidation.valid) {
+          return fail('INVALID_TARGET', targetValidation.reason);
+        }
       }
     }
 

--- a/apps/web/src/apps/TattleStation/InvitePanel.jsx
+++ b/apps/web/src/apps/TattleStation/InvitePanel.jsx
@@ -1,0 +1,98 @@
+import useGameStore from '../../stores/gameStore';
+import { useSocket } from '../../lib/SocketContext';
+
+export default function InvitePanel() {
+  const socket = useSocket();
+  const players = useGameStore((s) => s.players);
+  const selfId = useGameStore((s) => s.selfId);
+  const extrovertNightView = useGameStore((s) => s.extrovertNightView);
+  const pendingSelections = useGameStore((s) => s.pendingExtrovertSelections);
+  const toggleExtrovertTarget = useGameStore((s) => s.toggleExtrovertTarget);
+
+  if (!extrovertNightView) return null;
+
+  const confirmedTargetIds = extrovertNightView.confirmedTargetIds ?? null;
+  const hasSubmitted = confirmedTargetIds !== null;
+
+  const candidates = Object.values(players).filter(
+    (p) => p.alive && p.playerId !== selfId,
+  );
+
+  const selectedSet = new Set(
+    hasSubmitted ? confirmedTargetIds : (pendingSelections ?? []),
+  );
+
+  const handleConfirm = async () => {
+    if (hasSubmitted || selectedSet.size === 0) return;
+    try {
+      await socket.send('submitIntent', {
+        intent: {
+          type: 'SUBMIT_NIGHT_ACTION',
+          payload: {
+            actionType: 'CREATE_TEMP_CHAT',
+            targetPlayerIds: Array.from(selectedSet),
+            metadata: {},
+          },
+          clientTimestamp: new Date().toISOString(),
+        },
+      });
+    } catch (err) {
+      console.error('Failed to submit invite action:', err);
+    }
+  };
+
+  return (
+    <div
+      style={{
+        flex: 1,
+        display: 'flex',
+        flexDirection: 'column',
+        padding: 12,
+        background: '#1e293b',
+        color: '#e2e8f0',
+        fontFamily: 'Tahoma, sans-serif',
+        fontSize: 12,
+      }}
+    >
+      <div style={{ fontWeight: 'bold', marginBottom: 8, color: '#60a5fa' }}>
+        Invite players to a temporary group chat tonight.
+      </div>
+      <div style={{ flex: 1, overflowY: 'auto' }}>
+        {candidates.map((p) => {
+          const isSelected = selectedSet.has(p.playerId);
+          return (
+            <label
+              key={p.playerId}
+              style={{
+                padding: '6px 8px',
+                cursor: hasSubmitted ? 'default' : 'pointer',
+                background: isSelected ? '#1d4ed8' : 'transparent',
+                display: 'flex',
+                alignItems: 'center',
+                gap: 8,
+                borderRadius: 2,
+                marginBottom: 2,
+              }}
+            >
+              <input
+                type="checkbox"
+                checked={isSelected}
+                disabled={hasSubmitted}
+                onChange={() => !hasSubmitted && toggleExtrovertTarget(p.playerId)}
+              />
+              <span>{p.displayName}</span>
+            </label>
+          );
+        })}
+      </div>
+      <button
+        type="button"
+        onClick={handleConfirm}
+        disabled={hasSubmitted || selectedSet.size === 0}
+        style={{ marginTop: 8, padding: '6px 12px' }}
+      >
+        {hasSubmitted ? 'Submitted' : `Confirm (${selectedSet.size})`}
+      </button>
+    </div>
+  );
+}

--- a/apps/web/src/apps/TattleStation/NightPanel.jsx
+++ b/apps/web/src/apps/TattleStation/NightPanel.jsx
@@ -15,6 +15,9 @@ export default function NightPanel() {
   const nightKillTally = hackerNightView.tally ?? {};
   const confirmedNightKill = hackerNightView.confirmedTarget ?? null;
   const hasSubmitted = confirmedNightKill !== null;
+  const bossPlayerId = hackerNightView.bossPlayerId ?? null;
+  const selfIsBoss = bossPlayerId !== null && bossPlayerId === selfId;
+  const bossName = bossPlayerId ? players[bossPlayerId]?.displayName ?? null : null;
 
   const hackerSet = new Set([selfId, ...(myTeammates ?? [])]);
   const candidates = Object.values(players).filter(
@@ -56,6 +59,13 @@ export default function NightPanel() {
       <div style={{ fontWeight: 'bold', marginBottom: 8, color: '#f87171' }}>
         Pick a target to hack tonight.
       </div>
+      {bossPlayerId && (
+        <div style={{ marginBottom: 8, color: '#fbbf24', fontSize: 11 }}>
+          {selfIsBoss
+            ? 'You are The Boss — your selection is final.'
+            : `${bossName ?? 'The Boss'} has final say tonight.`}
+        </div>
+      )}
       <div style={{ flex: 1, overflowY: 'auto' }}>
         {candidates.map((p) => {
           const tally = nightKillTally[p.playerId] ?? 0;

--- a/apps/web/src/apps/TattleStation/index.jsx
+++ b/apps/web/src/apps/TattleStation/index.jsx
@@ -1,4 +1,4 @@
-import useGameStore, { selectIsHacker, selectIsWhiteHatHacker, selectIsSecuritySpecialist } from '../../stores/gameStore';
+import useGameStore, { selectIsHacker, selectIsWhiteHatHacker, selectIsSecuritySpecialist, selectIsExtrovert } from '../../stores/gameStore';
 import PhaseHeader from './PhaseHeader';
 import PlayerList from './PlayerList';
 import ChannelSidebar from './ChannelSidebar';
@@ -7,6 +7,7 @@ import VotePanel from './VotePanel';
 import NightPanel from './NightPanel';
 import InvestigatePanel from './InvestigatePanel';
 import ProtectPanel from './ProtectPanel';
+import InvitePanel from './InvitePanel';
 import NightSpectatorView from './NightSpectatorView';
 import SystemEventFeed from './SystemEventFeed';
 
@@ -18,6 +19,7 @@ function TattleStationComponent() {
   const isHacker = useGameStore(selectIsHacker);
   const isWhiteHatHacker = useGameStore(selectIsWhiteHatHacker);
   const isSecuritySpecialist = useGameStore(selectIsSecuritySpecialist);
+  const isExtrovert = useGameStore(selectIsExtrovert);
 
   const showVotePanel = phase === 'DAY_VOTE' && selfAlive;
   const showNightUi = phase === 'NIGHT_ACTIONS' && selfAlive;
@@ -32,6 +34,7 @@ function TattleStationComponent() {
       if (isHacker) return <NightPanel />;
       if (isWhiteHatHacker) return <InvestigatePanel />;
       if (isSecuritySpecialist) return <ProtectPanel />;
+      if (isExtrovert) return <InvitePanel />;
       return <NightSpectatorView />;
     }
     if (showSystemEvents) return <SystemEventFeed events={systemEvents} />;

--- a/apps/web/src/stores/gameStore.js
+++ b/apps/web/src/stores/gameStore.js
@@ -47,6 +47,10 @@ const initialState = {
   protectNightView: null,
   pendingProtectSelection: null,
 
+  // Extrovert slice
+  extrovertNightView: null,
+  pendingExtrovertSelections: [],
+
   // Session slice
   gameId: '',
   lobbyCode: '',
@@ -212,6 +216,23 @@ const useGameStore = create(
         state.pendingProtectSelection = null;
       }),
 
+    // --- Extrovert actions ---
+
+    toggleExtrovertTarget: (id) =>
+      set((state) => {
+        if (state.extrovertNightView?.confirmedTargetIds) return;
+        const list = state.pendingExtrovertSelections ?? [];
+        const idx = list.indexOf(id);
+        if (idx === -1) list.push(id);
+        else list.splice(idx, 1);
+        state.pendingExtrovertSelections = list;
+      }),
+
+    clearExtrovertSelections: () =>
+      set((state) => {
+        state.pendingExtrovertSelections = [];
+      }),
+
     // --- Session actions ---
 
     setElimination: (cause, cycle) =>
@@ -343,12 +364,14 @@ const useGameStore = create(
         state.myTeammates = view.myTeammates ?? [];
         state.hackerNightView = view.hackerNightView ?? null;
         state.protectNightView = view.protectNightView ?? null;
+        state.extrovertNightView = view.extrovertNightView ?? null;
         // Clear pending night selection on phase change
         if (previousPhase === 'NIGHT_ACTIONS' && view.phase !== 'NIGHT_ACTIONS') {
           state.pendingNightKillSelection = null;
           state.pendingInvestigateSelection = null;
           state.investigateSubmittedCycle = null;
           state.pendingProtectSelection = null;
+          state.pendingExtrovertSelections = [];
         }
         // Defense-in-depth: if the viewer's role was swapped away from
         // WHITE_HAT_HACKER mid-game (e.g. Jealous SWAP_ROLE), drop any stale
@@ -366,6 +389,12 @@ const useGameStore = create(
           view.myRole !== 'SECURITY_SPECIALIST'
         ) {
           state.pendingProtectSelection = null;
+        }
+        if (
+          previousSelfRole === 'EXTROVERT' &&
+          view.myRole !== 'EXTROVERT'
+        ) {
+          state.pendingExtrovertSelections = [];
         }
 
         // Session slice
@@ -399,6 +428,12 @@ export function selectIsWhiteHatHacker(state) {
 
 export function selectIsSecuritySpecialist(state) {
   if (state.selfRole !== 'SECURITY_SPECIALIST') return false;
+  const self = state.selfId ? state.players?.[state.selfId] : null;
+  return Boolean(self?.alive);
+}
+
+export function selectIsExtrovert(state) {
+  if (state.selfRole !== 'EXTROVERT') return false;
   const self = state.selfId ? state.players?.[state.selfId] : null;
   return Boolean(self?.alive);
 }

--- a/packages/shared/src/contracts/commands.ts
+++ b/packages/shared/src/contracts/commands.ts
@@ -48,6 +48,8 @@ export interface VoteIntentPayload {
 export interface NightActionIntentPayload {
   actionType: string;
   targetPlayerId?: string | null;
+  /** Multi-target list. Currently only consumed by CREATE_TEMP_CHAT (Extrovert). */
+  targetPlayerIds?: string[] | null;
   metadata?: Record<string, unknown>;
 }
 

--- a/packages/shared/src/contracts/views.ts
+++ b/packages/shared/src/contracts/views.ts
@@ -152,11 +152,22 @@ export interface HackerNightView {
   tally: Record<string, number>;
   /** Viewer's own confirmed HACKER_KILL target for the current cycle, if submitted. */
   confirmedTarget: string | null;
+  /**
+   * Player id of the living THE_BOSS, if any. The Boss's submitted target overrides
+   * plurality voting (see runtime-domain.ts resolveHackerKillTarget). Visible only to
+   * the Hacker team so other Hackers know whose vote will decide the kill.
+   */
+  bossPlayerId: string | null;
 }
 
 export interface ProtectNightView {
   /** Viewer's own confirmed PROTECT target for the current cycle, if submitted. */
   confirmedTarget: string | null;
+}
+
+export interface ExtrovertNightView {
+  /** Viewer's own confirmed CREATE_TEMP_CHAT invitee list for the current cycle, if submitted. */
+  confirmedTargetIds: string[] | null;
 }
 
 export interface PlayerSessionView {
@@ -188,6 +199,12 @@ export interface PlayerSessionView {
    * clients render ProtectPanel iff this is non-null.
    */
   protectNightView: ProtectNightView | null;
+  /**
+   * Extrovert-only night state. Non-null iff viewer is a living EXTROVERT
+   * AND phase is NIGHT_ACTIONS. Single discriminator — clients render
+   * InvitePanel iff this is non-null.
+   */
+  extrovertNightView: ExtrovertNightView | null;
   /**
    * Active communication restrictions affecting this viewer. Covert
    * restrictions (MONITORED) are always omitted. Populated by the


### PR DESCRIPTION
## Summary
- **Extrovert (#81)**: `CREATE_TEMP_CHAT` now accepts a multi-target list (`targetPlayerIds`). Adds `ExtrovertNightView` discriminator, `InvitePanel.jsx` checkbox UI, store slice, and validation. Legacy single-target payloads still resolve for backward compat.
- **The Boss (#85)**: a living `THE_BOSS`'s submitted kill target supersedes plurality voting among Hackers. Falls back to plurality when the Boss abstains, dies, or selects an invalid target (self / fellow Hacker). `HackerNightView` exposes `bossPlayerId` so the Hacker UI labels who has final say.

## Test plan
- [x] `npm test` — 229/229 pass (shared 2, server 166, web 61)
- [x] New `runtime-domain.test.ts` cases: 4 Boss-override scenarios + 2 multi-target CREATE_TEMP_CHAT scenarios
- [x] `projections.test.ts` updated for new `bossPlayerId` field
- [ ] Manual: confirm InvitePanel renders, multi-select submits, locked after submit
- [ ] Manual: confirm Boss override hint string in NightPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)